### PR TITLE
add destroy alias on receiving streams

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,8 @@ function Connection (conn) {
 
   conn.on('stream', function (stream) {
     stream.respond(200, {})
+    stream.destroy = stream.abort
+
     self.emit('stream', stream)
   })
 


### PR DESCRIPTION
WIP - ref: https://github.com/diasdavid/node-spdy-stream-muxer/issues/1

This adds an alias to .abort on the received streams, however, it is hard to alias the .abort on the returned stream since we want the dialStream to return a stream to buffer automatically while the stream is not ready (as requested previously here: https://github.com/diasdavid/abstract-stream-muxer/issues/1)
