### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,24 @@
 spdy-stream-muxer JavaScript implementation
-========================================
+==========================================
 
-[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io) [![](https://img.shields.io/badge/freejs-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
+# **DEPRECATED**
+
+## Use [libp2p-spdy](https://github.com/libp2p/js-libp2p-spdy) instead
+
+
+
+--------------------------------------------------------------
+--------------------------------------------------------------
+
+[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io) [![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
 
 > Abstraction on top of spdy-transport, implementing the abstract-stream-muxer interface
 
-[![](https://github.com/diasdavid/abstract-stream-muxer/blob/master/img/badge.png)](https://github.com/diasdavid/abstract-stream-muxer)
+[![](https://github.com/libp2p/interface-stream-muxer/blob/master/img/badge.png)](https://github.com/diasdavid/abstract-stream-muxer)
 
 # Usage
 
-spdy-stream-muxer follows the [abstract-stream-muxer API](https://github.com/diasdavid/abstract-stream-muxer#api)
+spdy-stream-muxer follows the [abstract-stream-muxer API](https://github.com/libp2p/interface-stream-muxer)
 
 # Example
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein
### GitHub Corrected URLs

| Was | Now |
| --- | --- |
| https://github.com/diasdavid/abstract-stream-muxer | https://github.com/libp2p/interface-stream-muxer |
| https://github.com/diasdavid/abstract-stream-muxer#api | https://github.com/libp2p/interface-stream-muxer |
| https://github.com/diasdavid/js-libp2p-spdy | https://github.com/libp2p/js-libp2p-spdy |
